### PR TITLE
remove link to gnosis safe app

### DIFF
--- a/src/components/AppLayout/MobileNotSupported/index.tsx
+++ b/src/components/AppLayout/MobileNotSupported/index.tsx
@@ -4,8 +4,6 @@ import styled from 'styled-components'
 import { ReactElement } from 'react'
 import { MobileView } from 'react-device-detect'
 
-import Phone from 'src/components/AppLayout/MobileStart/assets/phone@2x.png'
-
 const Overlay = styled.div`
   display: block;
   position: absolute;
@@ -46,29 +44,6 @@ const StyledCard = styled(Card)`
     min-width: 215px;
   }
 `
-const StyledImg = styled.img`
-  margin: 24px -81px 0 -58px;
-  z-index: 1;
-  width: 45%;
-  height: auto;
-  object-fit: cover;
-
-  @media (max-width: 340px) {
-    display: none;
-  }
-
-  @media (min-width: 430px) {
-    width: 30%;
-  }
-
-  @media (min-width: 720px) {
-    width: 25%;
-  }
-
-  @media (min-width: 800px) {
-    width: 20%;
-  }
-`
 
 const StyledCloseIcon = styled(Icon)`
   margin: 0 34px;
@@ -98,10 +73,6 @@ const StyledButton = styled(Button)`
   }
 `
 
-const StyledLink = styled.a`
-  text-decoration: none;
-`
-
 type Props = {
   onClose: () => void
 }
@@ -113,17 +84,7 @@ export const MobileNotSupported = ({ onClose }: Props): ReactElement => {
         <ModalApp>
           <StyledCard>
             <Text size="lg">The Celo Safe web app is not optimized for mobile.</Text>
-            <Text size="lg">Get the mobile app for a better experience.</Text>
-            <Button size="md" color="primary" variant="contained">
-              <StyledLink target="_blank" href="https://gnosis-safe.io/#mobile" rel="noopener noreferrer">
-                <Text color="white" size="xl">
-                  Get the App
-                </Text>
-              </StyledLink>
-            </Button>
           </StyledCard>
-
-          <StyledImg src={Phone} alt="Phone" />
           <StyledButton size="md" variant="outlined" color="primary" onClick={onClose}>
             <StyledCloseIcon size="md" type="cross" />
           </StyledButton>


### PR DESCRIPTION
## What it solves
When on mobile it was telling visitors to download the gnosis safe app

## How this PR fixes it

deletes the text and button

## How to test it

## Analytics changes

## Screenshots
