### PR TITLE
fix: substitute gnosis for celo

### DIFF
--- a/src/components/AppLayout/Footer/Footer.test.tsx
+++ b/src/components/AppLayout/Footer/Footer.test.tsx
@@ -14,9 +14,9 @@ describe('<Footer>', () => {
   it('Should show footer links', () => {
     render(<Footer />)
 
-    const gnosisCopyrightNode = screen.getByText(/©\d{4} cLabs/)
+    const cLabsCopyrightNode = screen.getByText(/©\d{4} cLabs/)
 
-    expect(gnosisCopyrightNode).toBeInTheDocument()
+    expect(cLabsCopyrightNode).toBeInTheDocument()
 
     const termsLinkNode = screen.getByText('Terms')
     expect(termsLinkNode).toBeInTheDocument()

--- a/src/components/GlobalErrorBoundary/index.tsx
+++ b/src/components/GlobalErrorBoundary/index.tsx
@@ -24,15 +24,6 @@ const Content = styled.div`
   }
 `
 
-const LinkWrapper = styled.div`
-  display: inline-flex;
-  margin-bottom: 10px;
-
-  > :first-of-type {
-    margin-right: 5px;
-  }
-`
-
 const LinkContent = styled.div`
   display: flex;
   align-items: center;
@@ -82,30 +73,6 @@ const GlobalErrorBoundaryFallback: FallbackRender = ({ error, componentStack }) 
       <Content>
         <Title size="md">Something went wrong, please try again.</Title>
         <FixedIcon type="networkError" />
-        {IS_PRODUCTION && (
-          <div>
-            <Text size="xl" as="span">
-              In case the problem persists, please reach out to us via{' '}
-            </Text>
-            <LinkWrapper>
-              <a target="_blank" href="email: mailto:safe@gnosis.io" rel="noopener noreferrer">
-                <Text color="primary" size="lg" as="span">
-                  Email
-                </Text>
-              </a>
-              <Icon type="externalLink" color="primary" size="sm" />
-            </LinkWrapper>
-            or{' '}
-            <LinkWrapper>
-              <a target="_blank" href="https://discordapp.com/invite/FPMRAwK" rel="noopener noreferrer">
-                <Text color="primary" size="lg" as="span">
-                  Discord
-                </Text>
-              </a>
-              <Icon type="externalLink" color="primary" size="sm" />
-            </LinkWrapper>
-          </div>
-        )}
         {!IS_PRODUCTION && (
           <>
             <Text size="xl" color="error">

--- a/src/routes/load/components/DetailsForm/index.tsx
+++ b/src/routes/load/components/DetailsForm/index.tsx
@@ -84,7 +84,7 @@ const DetailsForm = ({ errors, form, safeName }: DetailsFormProps): ReactElement
       <Block margin="md">
         <Paragraph color="primary" noMargin size="md">
           You are about to add an existing Celo Safe. First, choose a name and enter the Safe address. The name is only
-          stored locally and will never be shared with Gnosis or any third parties.
+          stored locally and will never be shared with Celo or any third parties.
           <br />
           Your connected wallet does not have to be the owner of this Safe. In this case, the interface will provide you
           a read-only view.

--- a/src/routes/safe/components/Apps/components/AppsList.tsx
+++ b/src/routes/safe/components/Apps/components/AppsList.tsx
@@ -140,7 +140,7 @@ const AppsList = (): React.ReactElement => {
           color="secondary"
           iconSize="sm"
           iconType="info"
-          text="These are third-party apps, which means they are not owned, controlled, maintained or audited by Gnosis. Interacting with the apps is at your own risk. Any communication within the Apps is for informational purposes only and must not be construed as investment advice to engage in any transaction."
+          text="These are third-party apps, which means they are not owned, controlled, maintained or audited by Celo. Interacting with the apps is at your own risk. Any communication within the Apps is for informational purposes only and must not be construed as investment advice to engage in any transaction."
           textSize="sm"
         />
       </ContentWrapper>

--- a/src/routes/safe/components/Settings/ManageOwners/index.tsx
+++ b/src/routes/safe/components/Settings/ManageOwners/index.tsx
@@ -83,7 +83,7 @@ const ManageOwners = ({ granted, owners }: Props): ReactElement => {
         </Heading>
         <Paragraph className={classes.annotation}>
           Add, remove and replace owners or rename existing owners. Owner names are only stored locally and never shared
-          with Gnosis or any third parties.
+          with Celo or any third parties.
         </Paragraph>
         <TableContainer>
           <Table

--- a/src/routes/welcome/components/index.tsx
+++ b/src/routes/welcome/components/index.tsx
@@ -66,6 +66,11 @@ const StyledButtonLink = styled(ButtonLink)`
   margin: 16px 0 16px -8px;
 `
 
+const Superscript = styled.span`
+  vertical-align: super;
+  font-size: 0.4em;
+`
+
 type Props = {
   isOldMultisigMigration?: boolean
 }
@@ -76,7 +81,7 @@ export const WelcomeLayout = ({ isOldMultisigMigration }: Props): React.ReactEle
     <Block>
       {/* Title */}
       <Title size="md" strong>
-        Welcome to Celo Safe.
+        Welcome to Celo Safe<Superscript> BETA</Superscript>
       </Title>
 
       {/* Subtitle */}


### PR DESCRIPTION
## What it solves

- Substitute Gnosis for Celo in the instances I could find
- Adds BETA to the text (ideally we'd add it to the image on the top left too)

## How to test it

I'm trying to make it work with Alfajores locally at the moment so I can get to the screens where the text used to say Celo.

## Screenshots

Before | After
---|---
<img width="588" alt="image" src="https://user-images.githubusercontent.com/21973269/159484917-13a29070-d6ab-4152-bcbb-7384b14b7174.png"> | <img width="587" alt="image" src="https://user-images.githubusercontent.com/21973269/159484945-55392b1b-5d06-4004-91e5-8190d688e3a0.png">
