### PR TITLE
Fix `ethBalance` in `fetchSafeTokens.ts`

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -39,6 +39,21 @@ export const getNetworkLabel = (id: ETHEREUM_NETWORK): string => {
   return cfg ? cfg.network.label : ''
 }
 
+// Returns true if the address points to a GoldToken proxy
+// on a support Celo network.
+export const isGoldTokenAddress = (address: string): boolean => {
+  switch (getNetworkId()) {
+    case ETHEREUM_NETWORK.ALFAJORES:
+      return address.toLowerCase() === '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9'.toLowerCase()
+    case ETHEREUM_NETWORK.MAINNET:
+      return address.toLowerCase() === '0x471EcE3750Da237f93B8E339c536989b8978a438'.toLowerCase()
+    case ETHEREUM_NETWORK.BAKLAVA:
+      return address.toLowerCase() === '0xdDc9bE57f553fe75752D61606B94CBD7e0264eF8'.toLowerCase()
+    default:
+      return false
+  }
+}
+
 export const usesInfuraRPC = false
 
 const getCurrentEnvironment = (): string => {

--- a/src/logic/tokens/store/actions/fetchSafeTokens.ts
+++ b/src/logic/tokens/store/actions/fetchSafeTokens.ts
@@ -10,6 +10,7 @@ import { addTokens } from 'src/logic/tokens/store/actions/addTokens'
 import { makeToken, Token } from 'src/logic/tokens/store/model/token'
 import { updateSafe } from 'src/logic/safe/store/actions/updateSafe'
 import { AppReduxState } from 'src/store'
+import { isGoldTokenAddress } from 'src/config'
 import { humanReadableValue } from 'src/logic/tokens/utils/humanReadableValue'
 import { currentSafe } from 'src/logic/safe/store/selectors'
 import BigNumber from 'bignumber.js'
@@ -41,8 +42,9 @@ const extractDataFromResult = (
     tokenBalance: humanReadableValue(balance, Number(decimals)),
   })
 
-  // Extract network token balance from backend balances
-  if (sameAddress(address, ZERO_ADDRESS)) {
+  // Extract network token balance from backend balances.
+  // Treat GoldToken address as Celo balance here.
+  if (sameAddress(address, ZERO_ADDRESS) || isGoldTokenAddress(address)) {
     acc.ethBalance = humanReadableValue(balance, Number(decimals))
   } else {
     acc.tokens = acc.tokens.push(makeToken({ ...tokenInfo }))


### PR DESCRIPTION
## What it solves
- Previously in fetch balance only token balances associated with
    address(0) were counted towards ethBalance. This led to an
    underestimate of the Celo balance in the modal flows since
    the API call to blockscout only fetches ERC-20 token balances.
- While this was minorly inconvenient in the "Send funds" flow,
    this actually became a blocker in the "Contract interaction"
    flow because the composite validity checker enforces that
    you cannot send more than max of value.

## How this PR fixes it
- Accepts GoldTokenProxy addresses as well when we
   are deciding what to add to "ethBalance" so that we
   can unblock the "Contract interaction" flow.

## How to test it
- Use dapp on modal screens

## Screenshots
Before:
<img width="1620" alt="Screen Shot 2022-07-25 at 11 46 20 PM" src="https://user-images.githubusercontent.com/14866173/180946484-da6805f1-1e91-4054-bfed-7b8385e822f8.png">
<img width="1412" alt="Screen Shot 2022-07-26 at 12 07 28 AM" src="https://user-images.githubusercontent.com/14866173/180946477-bc90cfa4-7410-449a-8b6d-cfe2ef759bac.png">

After:
<img width="1624" alt="Screen Shot 2022-07-25 at 11 46 39 PM" src="https://user-images.githubusercontent.com/14866173/180946521-6e2e5600-9416-433c-8c00-20f81ec03a98.png">
<img width="1621" alt="Screen Shot 2022-07-25 at 11 46 30 PM" src="https://user-images.githubusercontent.com/14866173/180946531-3064d074-a2e2-4881-80ed-ab91c8400b68.png">