### PR TITLE
Merge proxy & implementation contract ABIs

### DIFF
--- a/src/logic/wallets/ethAddresses.ts
+++ b/src/logic/wallets/ethAddresses.ts
@@ -13,6 +13,15 @@ export const isEmptyAddress = (address: string | undefined): boolean => {
   return sameAddress(address, EMPTY_DATA) || sameAddress(address, ZERO_ADDRESS)
 }
 
+// Helper function for formatting ethereum addresses.
+// If input address if longer than 40 bytes, takes the last 40 and adds "0x" prefix
+export const formatAddress = (address: string): string => {
+  if (address.length > 40) {
+    address = address.substring(address.length - 40, address.length)
+  }
+  return `0x${address}`
+}
+
 export const shortVersionOf = (value: string, cut: number): string => {
   if (!value) {
     return 'Unknown'


### PR DESCRIPTION
# What it solves
Today it is hard to interact with proxy contracts on Celo Safe
because only the proxy contract ABI is loaded from Blockscout.

See #37 

# How this PR solves it
This PR performs a simple check for each address provided in the
"contract interaction" modal flow by querying for an implementation
contract address in the implementation slot designed in EIP-1967.
If the address exists, then we attempt to fetch that ABI and merge 
it with the proxy contract ABI (this is very similar to what Blockscout does)

# How to test it
Try the "contract interaction" flow with a proxy contract address.
Should be able to execute transaction on methods on the implementation
contract ABI.

## Screenshots
<img width="2240" alt="Screen Shot 2022-07-26 at 4 44 46 PM" src="https://user-images.githubusercontent.com/14866173/181131789-649ca258-cf64-458b-8045-72a7dd7f9327.png">
