### PR TITLE
Move to the new explorer url

### DIFF
--- a/src/config/networks/mainnet.ts
+++ b/src/config/networks/mainnet.ts
@@ -21,8 +21,8 @@ const baseConfig: EnvironmentSettings = {
   safeAppsRpcServiceUrl: 'https://forno.celo.org',
   rpcServiceUrl: 'https://forno.celo.org',
   networkExplorerName: 'Blockscout',
-  networkExplorerUrl: 'https://explorer.celo.org',
-  networkExplorerApiUrl: 'https://explorer.celo.org/api',
+  networkExplorerUrl: 'https://explorer.celo.org/mainnet',
+  networkExplorerApiUrl: 'https://explorer.celo.org/mainnet/api',
 }
 
 const mainnet: NetworkConfig = {


### PR DESCRIPTION
## What it solves
Celo Safe was hitting the old explorer url

## How this PR fixes it
Move to the new url

